### PR TITLE
Fix GD owner finding when multiple owners are present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,11 +1711,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "leaky-bucket-lite"
-version = "0.5.2"
+name = "leaky-bucket"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1411c737dd21a748044ab29af14b7f920b2dcc277284df6dd986492c98bf5229"
+checksum = "0a396bb213c2d09ed6c5495fd082c991b6ab39c9daf4fff59e6727f85c73e4c5"
 dependencies = [
+ "parking_lot",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2440,6 +2442,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "rosu-v2"
-version = "0.10.0"
-source = "git+https://github.com/jamesbt365/rosu-v2?branch=new-types#25359b5a7a7c7ee372bf14ae663c5557ffd25b8b"
+version = "0.11.0"
+source = "git+https://github.com/MaxOhn/rosu-v2?branch=lazer#a5c8b58d4db3c1d090d68c2ea903511bda538bad"
 dependencies = [
  "bytes",
  "dashmap 6.1.0",
@@ -2937,7 +2959,8 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "itoa",
- "leaky-bucket-lite",
+ "leaky-bucket",
+ "pin-project",
  "rosu-mods",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rustrict = "0.7.33"
 regex = "1.11.1"
 serde = "1"
 serde_json = "1"
-rosu-v2 = { git = "https://github.com/jamesbt365/rosu-v2", branch = "new-types" }
+rosu-v2 = { git = "https://github.com/MaxOhn/rosu-v2", branch = "lazer" }
 handlebars = { version = "6.3.2", features = ["dir_source"] }
 
 [workspace.dependencies.serenity]

--- a/moth_core/src/verification/roles.rs
+++ b/moth_core/src/verification/roles.rs
@@ -1,7 +1,7 @@
 use rosu_v2::{
     model::GameMode,
-    prelude::{RankStatus, UserExtended},
     model::user::UserBeatmapsetsKind,
+    prelude::{RankStatus, UserExtended},
 };
 use serenity::all::{
     CreateEmbed, CreateEmbedAuthor, CreateMessage, EditMember, GenericChannelId, GuildId,
@@ -457,7 +457,7 @@ async fn handle_maps(
 
         for mapset in mapsets {
             for map in mapset.maps.expect("always sent") {
-                if map.creator_id == user_id {
+                if map.creator_id == user_id || map.owners.unwrap_or_default().iter().any(|x| x.user_id == user_id) {
                     match map.status {
                         RankStatus::Ranked | RankStatus::Approved => match map.mode {
                             GameMode::Osu => holder.set_ranked_std(true),

--- a/moth_core/src/verification/roles.rs
+++ b/moth_core/src/verification/roles.rs
@@ -1,7 +1,7 @@
 use rosu_v2::{
     model::GameMode,
     prelude::{RankStatus, UserExtended},
-    request::MapType,
+    model::user::UserBeatmapsetsKind,
 };
 use serenity::all::{
     CreateEmbed, CreateEmbedAuthor, CreateMessage, EditMember, GenericChannelId, GuildId,
@@ -419,12 +419,12 @@ enum MapTypeChoice {
     GuestEither,
 }
 
-impl From<MapTypeChoice> for MapType {
+impl From<MapTypeChoice> for UserBeatmapsetsKind {
     fn from(val: MapTypeChoice) -> Self {
         match val {
-            MapTypeChoice::Loved => MapType::Loved,
-            MapTypeChoice::Ranked => MapType::Ranked,
-            MapTypeChoice::GuestEither => MapType::Guest,
+            MapTypeChoice::Loved => UserBeatmapsetsKind::Loved,
+            MapTypeChoice::Ranked => UserBeatmapsetsKind::Ranked,
+            MapTypeChoice::GuestEither => UserBeatmapsetsKind::Guest,
         }
     }
 }
@@ -444,8 +444,7 @@ async fn handle_maps(
 
     loop {
         let Ok(mapsets) = osu
-            .user_beatmapsets(user_id)
-            .status(&map_type.into())
+            .user_beatmapsets(user_id, map_type.into())
             .offset(offset)
             .limit(5)
             .await


### PR DESCRIPTION
Hopefully this works. I have absolutely no clue how to test this (even if I run the bot myself it would be kinda hard) but I don't see any reason why it wouldnt work.

I set up a dummy database for it this time so this at least isnt going totally blind and the linter/analyzer is happy.

Related: https://osu.ppy.sh/docs/index.html#beatmapowner

<img width="451" height="67" alt="Image" src="https://github.com/user-attachments/assets/41ed9991-59c8-4880-88a9-941b3011581b" />

Utiba is our test subject here in the server. It should fix them not having a catch ranked role. They have a GD on this map that isn't detecting currently https://osu.ppy.sh/beatmapsets/2237688#fruits/4786999.