### PR TITLE
Add debounce time of 1 second between deletes for mass delete to fetch

### DIFF
--- a/moth_core/src/data/structs.rs
+++ b/moth_core/src/data/structs.rs
@@ -165,7 +165,8 @@ pub struct InnerCache {
 }
 pub struct Decay {
     pub val: u16,
-    pub last_update: Instant,
+    pub recorded_at: Instant,
+    pub last_updated: Instant,
 }
 
 impl AntiDeleteCache {
@@ -175,7 +176,7 @@ impl AntiDeleteCache {
         let mut to_remove = vec![];
         for mut entry in self.val.iter_mut() {
             let guild = entry.value_mut();
-            let elapsed = now.duration_since(guild.last_update).as_secs();
+            let elapsed = now.duration_since(guild.recorded_at).as_secs();
             // time without messages deleted to decay, hardcoded currently.
             if elapsed > 5 {
                 guild.val -= 1;

--- a/moth_events/src/handlers/messages/anti_delete.rs
+++ b/moth_events/src/handlers/messages/anti_delete.rs
@@ -48,22 +48,26 @@ pub async fn anti_delete(
 ) -> Option<UserId> {
     // increase value.
     {
+        let now = Instant::now();
         let Some(mut value) = data.anti_delete_cache.val.get_mut(&guild_id) else {
             data.anti_delete_cache.val.insert(
                 guild_id,
                 Decay {
                     val: 1,
-                    last_update: Instant::now(),
+                    recorded_at: now,
+                    last_updated: now,
                 },
             );
             return None;
         };
+        let secs_since_last_updated = now.duration_since(value.last_updated).as_secs();
         if value.val > 0 && value.val < 5 {
             value.val += 1;
-            // low heat = no check.
-            if value.val < 3 {
-                return None;
-            }
+            value.last_updated = now;
+        }
+        // low heat or debounce = no check.
+        if value.val < 3 || secs_since_last_updated < 1 {
+            return None;
         }
     }
     let last_deleted = {


### PR DESCRIPTION
A quick explanation of how anti mass delete works first since I'm not sure you've looked into it.

1. Every time a message is deleted, a heat value is put on the guild it was deleted from.
2. After 5 seconds from a delete being recorded in a guild, the heat starts decaying. It goes down by 1 every 2 seconds.
3. The heat caps out at 5. If the heat reaches 3-5, an anti mass delete check is initiated. First, the cache is checked and if nothing is found, a fetch messages request is made to discord to pull all messages surrounding the deleted message into cache.
4. If the heat drops to 0, the guild is removed from the anti mass delete watch.

I've added a timer since the last change in heat. If the heat was changed less than 1 second ago and another anti mass delete event is triggered, even if it's high heat, dont do anything.

From what I understand with what phil has said on how fast these torrents of deletes hit, this should be plenty.

Something to note: the `last_updated` struct field was previously not tracking when `val` was last updated, it tracked when the struct was created. So I moved that to `recorded_at` instead since I need real `last_updated` tracking for the debounce.