### PR TITLE
Add tracking of amount of anti delete calls in 10 minutes

### DIFF
--- a/moth_core/src/data/structs.rs
+++ b/moth_core/src/data/structs.rs
@@ -6,7 +6,7 @@ use serenity::all::{ChannelId, Member, RoleId, SecretString};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use lumi::serenity_prelude::{GenericChannelId, GuildId, MessageId, UserId};
@@ -153,11 +153,15 @@ impl DmActivity {
     }
 }
 
+pub const ANTI_DELETE_CACHE_CYCLE_TIME: Duration = Duration::from_mins(10);
+pub const ANTI_DELETE_MAX_DELETES_PER_CYCLE: usize = 1000;
 #[derive(Default)]
 pub struct AntiDeleteCache {
     pub val: DashMap<GuildId, Decay>,
     // Dashmap using guild key, containing the last deleted msg and a hashmap of stored message ids.
     pub map: DashMap<GuildId, InnerCache>,
+    // this may get a lot of writes very fast, std rwlock has reader bias which can choke writers so use fairer tokio rwlock
+    pub deletes_per_cycle: tokio::sync::RwLock<usize>,
 }
 pub struct InnerCache {
     pub last_deleted_msg: MessageId,

--- a/moth_events/src/handlers/messages/anti_delete.rs
+++ b/moth_events/src/handlers/messages/anti_delete.rs
@@ -1,6 +1,6 @@
 use crate::Data;
 use lumi::serenity_prelude as serenity;
-use moth_core::data::structs::{Decay, InnerCache};
+use moth_core::data::structs::{ANTI_DELETE_MAX_DELETES_PER_CYCLE, Decay, InnerCache};
 use serenity::{GenericChannelId, GetMessages, GuildId, MessageId, UserId};
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
@@ -46,6 +46,7 @@ pub async fn anti_delete(
     guild_id: GuildId,
     deleted_message_id: MessageId,
 ) -> Option<UserId> {
+    *data.anti_delete_cache.deletes_per_cycle.write().await += 1; // no need to scope since there's no let binding
     // increase value.
     {
         let now = Instant::now();
@@ -65,8 +66,12 @@ pub async fn anti_delete(
             value.val += 1;
             value.last_updated = now;
         }
-        // low heat or debounce = no check.
-        if value.val < 3 || secs_since_last_updated < 1 {
+        // low heat or debounce or cycle overflow = no check.
+        if value.val < 3
+            || secs_since_last_updated < 1
+            || *data.anti_delete_cache.deletes_per_cycle.read().await
+                > ANTI_DELETE_MAX_DELETES_PER_CYCLE
+        {
             return None;
         }
     }

--- a/moth_events/src/handlers/misc.rs
+++ b/moth_events/src/handlers/misc.rs
@@ -1,5 +1,6 @@
 use crate::{Data, Error};
 use lumi::serenity_prelude::{self as serenity, Ready};
+use moth_core::data::structs::ANTI_DELETE_CACHE_CYCLE_TIME;
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -34,6 +35,15 @@ async fn finalize_start(ctx: &serenity::Context) {
         loop {
             interval.tick().await;
             data_clone.anti_delete_cache.decay_proc();
+        }
+    });
+
+    let data_clone = data.clone();
+    tokio::spawn(async move {
+        let mut interval: tokio::time::Interval = tokio::time::interval(ANTI_DELETE_CACHE_CYCLE_TIME);
+        loop {
+            interval.tick().await;
+            *data_clone.anti_delete_cache.deletes_per_cycle.write().await = 0;
         }
     });
 


### PR DESCRIPTION
Not sure what the best value here would for the max be but more than 2000 deletes in 10 minutes is a pretty insane amount and well below discord's max of 10000 requests per 10 minutes. Have to leave room for other things happening ofc so maybe it should be lower but this should at least prevent too much chaos from happening.